### PR TITLE
feat: add developers block for Central Portal validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,21 @@
     <tag>HEAD</tag>
   </scm>
 
+  <!--
+    | Required by the Central Publisher Portal (OSSRH Staging API): deployments
+    | without a <developers> element are rejected with 'Developers information
+    | is missing'. Every portlet project inheriting from this parent picks this
+    | up automatically so no per-project fix is needed. Points at the uPortal
+    | committers page rather than any single repo's contributors list since
+    | this parent serves the whole ecosystem.
+  +-->
+  <developers>
+    <developer>
+      <organization>uPortal Developers</organization>
+      <organizationUrl>https://github.com/uPortal-Project/uPortal/blob/master/docs/COMMITTERS.md</organizationUrl>
+    </developer>
+  </developers>
+
   <properties>
     <scm-base>https://raw.githubusercontent.com/uPortal-project/uportal-portlet-parent/master/</scm-base>
 


### PR DESCRIPTION
## Summary

Add a `<developers>` element so that every portlet inheriting from this parent satisfies the Central Publisher Portal validation without each project having to add its own copy.

## Why

The Central Publisher Portal rejects deployments whose POMs lack `<developers>` info with:

```
HTTP 400
{"error":"Failed to process request: Deployment reached an unexpected status: Failed
pkg:maven/<groupId>/<artifactId>@<version>
- Developers information is missing"}
```

Discovered during the resource-server 1.5.x release attempt: artifacts made it through `mvn release:perform`, got signed with GPG, and uploaded to the OSSRH staging endpoint — only to fail validation at the manual-upload step. Adding the block per-project across every portlet is tedious and error-prone; centralizing it here is the right layer.

## The block

```xml
<developers>
  <developer>
    <organization>uPortal Developers</organization>
    <organizationUrl>https://github.com/uPortal-Project/uPortal/blob/master/docs/COMMITTERS.md</organizationUrl>
  </developer>
</developers>
```

Placed right after `<scm>`. Points at the canonical `COMMITTERS.md` in the main `uPortal` repo rather than any specific project's contributors page — this parent serves the whole ecosystem.

## Release plan

After this merges, a new version of `uportal-portlet-parent` (presumably `44`) should be released so downstream portlets can consume it. Each portlet's `pom.xml` would then bump `<parent><version>43</version>` → `44`. Until that release happens, portlets hitting this issue can override locally (as `resource-server` did in `uPortal-Project/resource-server#325`).

## Test plan

- [ ] `mvn clean install` — basic smoke test that the POM still parses
- [ ] After parent release, bump a portlet to the new parent version and verify the deployed POM contains the `<developers>` block
- [ ] Verify Central Portal upload of that portlet no longer returns the developers-missing error