### PR TITLE
feat: v44 prep — Central Portal URLs, Java 11, drop oss-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,30 @@
     </developer>
   </developers>
 
+  <!--
+    | Central Publisher Portal (OSSRH Staging API compatibility service).
+    | Shadows the stale oss.sonatype.org URLs inherited from
+    | org.sonatype.oss:oss-parent:9. Every descendant portlet picks up
+    | the correct URLs automatically — no per-project override needed.
+    |
+    | The OSSRH host oss.sonatype.org was sunset in June 2025. Server id
+    | 'sonatype-nexus-staging' is preserved so existing ~/.m2/settings.xml
+    | credential entries keep working; the URL is what changed. Descendants
+    | may also use the 'central' server id (Central Portal's canonical name).
+  +-->
+  <distributionManagement>
+    <repository>
+      <id>sonatype-nexus-staging</id>
+      <name>Central Portal Release Repository</name>
+      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
+    </repository>
+    <snapshotRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Central Portal Snapshot Repository</name>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
+
   <properties>
     <scm-base>https://raw.githubusercontent.com/uPortal-project/uportal-portlet-parent/master/</scm-base>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,11 +22,15 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>9</version>
-  </parent>
+  <!--
+    | Previously inherited from org.sonatype.oss:oss-parent:9, which is
+    | unmaintained and was the source of the dead oss.sonatype.org
+    | distributionManagement URLs. The two things that parent provided
+    | and we still need — the distribution URLs and the source/javadoc/gpg
+    | release bindings — are now declared explicitly in this POM (see
+    | <distributionManagement> above and the <central-portal-release>
+    | profile below).
+  +-->
 
   <groupId>org.jasig.portlet</groupId>
   <artifactId>uportal-portlet-parent</artifactId>
@@ -377,7 +381,7 @@
           <configuration>
             <mavenExecutorId>forked-path</mavenExecutorId>
             <useReleaseProfile>false</useReleaseProfile>
-            <arguments>${additionalReleaseArguments} -Psonatype-oss-release,jasig-release</arguments>
+            <arguments>${additionalReleaseArguments} -Pcentral-portal-release,jasig-release</arguments>
           </configuration>
           <dependencies>
             <dependency>
@@ -690,6 +694,59 @@
   </reporting>
 
   <profiles>
+    <!--
+      | Replicates the attach-sources / attach-javadocs / sign-artifacts
+      | bindings that previously came from the 'sonatype-oss-release' profile
+      | in org.sonatype.oss:oss-parent:9. Invoked by the maven-release-plugin
+      | configuration above (-Pcentral-portal-release). Renamed from the
+      | old profile id so it's clear which flow is in play.
+    +-->
+    <profile>
+      <id>central-portal-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.3.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.2.8</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>jasig-release</id>
       <!-- used by release plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,8 @@
     <jasig-notice-template-url>${scm-base}licenses/NOTICE.template</jasig-notice-template-url>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <additionalReleaseArguments />
 
     <maven.site.plugin.ver>3.12.0</maven.site.plugin.ver>
@@ -314,8 +314,8 @@
             - maven.compiler.target
           -->
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <source>${maven.compiler.source}</source>
+            <target>${maven.compiler.target}</target>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
## Summary

Three related changes to make `uportal-portlet-parent:44` a proper "one-stop-shop" parent for the portlet ecosystem post-OSSRH-sunset. Each lands as its own commit so they can be reviewed independently.

## Commits

### 1. `feat: override distributionManagement for Central Portal`

Shadow the stale `oss.sonatype.org` URLs inherited from `org.sonatype.oss:oss-parent:9` with the Central Publisher Portal's OSSRH Staging API compatibility service. With this, descendants no longer need a per-project override to successfully release.

- Release: `https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/`
- Snapshot: `https://central.sonatype.com/repository/maven-snapshots/`
- Server id `sonatype-nexus-staging` preserved for ~/.m2/settings.xml compatibility

### 2. `feat: bump Java 1.8 → 11`

Every portlet inheriting from this parent is moving to Java 11. Driven by dep upgrades like `maven-notice-plugin:2.0.0` that require modern JAXB (removed from the JDK after 8). Literal `1.8` in the compiler plugin config replaced with `${maven.compiler.source}` references so future bumps only need a property change.

### 3. `feat: drop oss-parent:9 inheritance, self-contain release profile`

`org.sonatype.oss:oss-parent:9` hasn't been released since 2012 and was the source of the dead distribution URLs that commit 1 had to shadow. This commit removes the inheritance entirely and self-contains the two things the descendants actually used:

- distributionManagement (from commit 1)
- a new `central-portal-release` profile that replicates the `sonatype-oss-release` profile's bindings: `maven-source-plugin:jar-no-fork`, `maven-javadoc-plugin:jar`, `maven-gpg-plugin:sign`

The `maven-release-plugin` `<arguments>` is updated to invoke `-Pcentral-portal-release,jasig-release`.

Verified `mvn help:effective-pom -N` succeeds after the change.

## Why now / why together

Surfaced during the April 2026 `resource-server:1.5.2` release. Every one of these overrides had to be applied per-project to land that release — the same 3 fixes will be needed for each of the ~10 portlets still on `jasig-parent` or older `uportal-portlet-parent` versions. Fixing them here means the downstream bumps become trivial `<parent><version>43→44</version>` changes.

Bundling the commits into one PR avoids three separate release cycles of the parent for mechanically-related changes.

## Descendant migration after v44 releases

Per-project changes needed when bumping to v44:

- `<parent><version>43</version>` → `44`
- Remove any per-project `<developers>` override (now inherited)
- Remove any per-project `<distributionManagement>` override (now inherited)
- Confirm Java 11 works (or add a `<maven.compiler.source>` override if a specific component needs otherwise)

Known candidates:
- `resource-server` (at v43 now; next release ships as 1.5.3)
- `NewsReaderPortlet` (at v42)
- `WebproxyPortlet` (at v42)
- 8 portlets still on `jasig-parent` — bigger migration, separate PRs

## Test plan

- [x] `mvn help:effective-pom -N` — BUILD SUCCESS
- [ ] Release v44 to Maven Central via the updated flow to validate `central-portal-release` profile end-to-end
- [ ] Bump one downstream portlet to v44 as a smoke test (probably `resource-server` → 1.5.3) before marking the ecosystem migration complete

## Spring Boot note

Portlets/webapps whose parent is `spring-boot-starter-parent` (e.g. `esup-filemanager`, the `resource-server-webapp` submodule) can't inherit from this parent — they need SB's classloader and dep management. Those projects should still add the `<developers>` block and Central Portal `<distributionManagement>` directly. That pattern is documented in the ecosystem release guide.