### PR TITLE
fix: define spring-data.version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,25 @@
     <findbugs.maven.plugin.ver>3.0.5</findbugs.maven.plugin.ver>
     <jdepend.maven.plugin.ver>2.0</jdepend.maven.plugin.ver>
 
-    <!-- Common dependency versions -->
+    <!--
+      | Common dependency versions.
+      |
+      | tomcat.version, portlet-api.version, servlet.version, jstl.version
+      | and the other container-provided spec versions below MUST track the
+      | Tomcat shipped by uPortal-start. These dependencies are not bundled
+      | into portlet WARs; the container's shared/lib provides them at
+      | runtime, so the compile-time version has to match what will actually
+      | be on the classpath in production.
+      |
+      | When the Tomcat version changes in uPortal-start, update tomcat.version
+      | here (and any companion spec versions affected by the Tomcat bump)
+      | and release a new uportal-portlet-parent. Every descendant picks up
+      | the synchronized set via inheritance — no per-portlet change needed.
+      |
+      | Corollary: descendants SHOULD NOT redeclare these dependencies with
+      | their own <version>. A per-portlet pin desyncs from what the
+      | container provides and risks compile-against-X / runtime-Y bugs.
+    +-->
     <tomcat.version>8.5.89</tomcat.version>
     <spring.version>5.3.28</spring.version>
     <portletmvc4spring.version>5.2.0</portletmvc4spring.version>
@@ -153,8 +171,22 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Default Tomcat 8.5 provided dependencies -->
-      <!-- See https://tomcat.apache.org/whichversion.html -->
+      <!--
+        | Tomcat-provided runtime dependencies.
+        |
+        | These artifacts ship with the Tomcat container (shared/lib) in
+        | uPortal-start, so they are NOT bundled into the portlet WAR at
+        | build time — scope is 'provided'. The compile-time version MUST
+        | match the runtime Tomcat version or you get compile-against-X /
+        | runtime-Y bugs.
+        |
+        | Descendants must not redeclare these with their own <version>.
+        | When uPortal-start's Tomcat version bumps, update tomcat.version
+        | above and cut a new parent release; descendants inherit the fix.
+        |
+        | See https://tomcat.apache.org/whichversion.html for the spec
+        | version each Tomcat minor line implements.
+      +-->
       <dependency>
         <groupId>org.apache.tomcat</groupId>
         <artifactId>tomcat-servlet-api</artifactId>
@@ -233,7 +265,15 @@
         </exclusions>
       </dependency>
 
-      <!-- uPortal common portlet dependencies places in shared/lib -->
+      <!--
+        | Portlet API and Pluto taglib — also provided at runtime, placed
+        | by uPortal-start into the Tomcat shared/lib. Same invariant as
+        | the Tomcat-provided block above: descendants inherit these
+        | versions, do not redeclare with their own <version>.
+        |
+        | If uPortal-start changes the JSR-286 Portlet API level (2.0 vs
+        | 3.0+) or the Pluto version, bump here and release a new parent.
+      +-->
       <dependency>
         <groupId>javax.portlet</groupId>
         <artifactId>portlet-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,7 @@
     +-->
     <tomcat.version>8.5.89</tomcat.version>
     <spring.version>5.3.28</spring.version>
+    <spring-data.version>2.7.18</spring-data.version>
     <portletmvc4spring.version>5.2.0</portletmvc4spring.version>
     <portlet-api.version>2.0</portlet-api.version>
     <logback.version>1.3.5</logback.version>


### PR DESCRIPTION
## Summary

Define the missing \`spring-data.version\` property. The \`spring-data-jpa\` entry in \`dependencyManagement\` references it but the property was never declared, so any descendant declaring \`spring-data-jpa\` against this parent hits:

\`\`\`
'dependencies.dependency.version' for org.springframework.data:spring-data-jpa:jar
must be a valid version but is '\${spring-data.version}'
\`\`\`

This blocked **AnnouncementsPortlet**'s migration from \`jasig-parent:41\` during the v44 rollout — it declares \`spring-data-jpa\`, so inheriting v44 fails immediately. Same issue waiting for any future descendant that needs Spring Data JPA.

## The fix

One new property alongside \`spring.version\`:

\`\`\`xml
<spring.version>5.3.28</spring.version>
<spring-data.version>2.7.18</spring-data.version>
<portletmvc4spring.version>5.2.0</portletmvc4spring.version>
\`\`\`

Pinning \`2.7.18\`:

- Aligns with the Spring Data JPA 2.7 line, which is compatible with the parent's \`spring.version=5.3.28\` (Spring Framework 5.3.x).
- Matches what \`resource-server\` consumes explicitly in its own \`dependencyManagement\` — keeping descendants of this parent in sync with the \`resource-server\` release line avoids transitive version skew.

Descendants on older Spring lines can still override the property locally; this PR just provides a sensible default for the v45 consumers.

## Why now

Unblocks AnnouncementsPortlet's migration so it can land alongside the other portlet parent-bumps for the upcoming uPortal release cycle.

## Test plan

- [x] \`mvn help:effective-pom -N\` — BUILD SUCCESSFUL
- [ ] After v45 release, AnnouncementsPortlet \`jasig-parent:41 → uportal-portlet-parent:45\` should validate cleanly (blocked on v44 with the same property issue)

## Release plan

Cut **uportal-portlet-parent:45** after this merges. The 8 open portlet parent-migration PRs already targeting v44 get retargeted to v45 once available, unblocking AnnouncementsPortlet at the same time.

## Note on CoursesPortlet

The separate \`spring-framework-bom:3.2.3.RELEASE\` failure that blocked CoursesPortlet is **not** addressed here — that's caused by CoursesPortlet setting its own \`spring.version=3.2.3.RELEASE\` locally, which then resolves the parent's \`spring-framework-bom:\${spring.version}\` import to a version that doesn't exist (Spring 3.x never shipped a BOM). Fixing CoursesPortlet is a separate track that requires bumping its Spring version first.