### PR TITLE
fix: relax slf4j-bridge bans for transitional portlets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -534,17 +534,28 @@
                   </requireJavaVersion>
                   <bannedDependencies>
                     <excludes>
-                      <exclude>commons-collections:commons-collections:[3.2.1,4.0]</exclude>
+                      <!-- CVE-driven: commons-collections 3.2.x contains
+                           CVE-2015-6420 (RCE via deserialization). -->
                       <exclude>commons-collections:commons-collections:[3.2.1,4.0]</exclude>
                       <!-- Transitively brought in by portlet-mvc-util, should not be included -->
                       <exclude>javax.servlet:servlet-api</exclude>
-                      <!-- Logging bridges are brought in through spring-jcl (5+) -->
-                      <exclude>org.slf4j:log4j-over-slf4j</exclude>
-                      <exclude>org.slf4j:jcl-over-slf4j</exclude>
-                      <!-- Only using slf4j and logback for logging -->
+                      <!-- Only using slf4j and logback for logging; log4j
+                           1.x is EOL, log4j 2.x has historical CVEs and is
+                           not the project's chosen binding. -->
                       <exclude>commons-logging:commons-logging</exclude>
                       <exclude>org.apache.logging.log4j</exclude>
                       <exclude>log4j</exclude>
+                      <!--
+                        | Intentionally NOT banned here (as of v46):
+                        |   org.slf4j:log4j-over-slf4j
+                        |   org.slf4j:jcl-over-slf4j
+                        | These are legitimate slf4j bridges that portlets
+                        | on Spring 4.x still need (Spring 5+ ships spring-jcl
+                        | which obsoletes jcl-over-slf4j, but several
+                        | descendants are still on Spring 4.x during the
+                        | modernization cycle). Re-introduce the bans once
+                        | all descendants have moved to Spring 5+.
+                      +-->
                     </excludes>
                   </bannedDependencies>
                 </rules>


### PR DESCRIPTION
## Summary

Remove the bans on `org.slf4j:log4j-over-slf4j` and `org.slf4j:jcl-over-slf4j` from the `maven-enforcer-plugin` `bannedDependencies` rule. These are legitimate slf4j bridges that portlets on Spring 4.x still need.

## Context

The v45 migration sweep tried to move 10 descendants (9 portlets + resource-server) to `uportal-portlet-parent:45`. **8 of 10 failed CI** with BannedDependencies errors on transitive slf4j bridges.

- `resource-server#326` ✅
- `WebproxyPortlet#253` ✅
- `AnnouncementsPortlet#317`, `NewsReaderPortlet#413`, `basiclti-portlet#53`, `BookmarksPortlet#127`, `CalendarPortlet#368`, `FeedbackPortlet#92`, `JasigWidgetPortlets#281`, `SimpleContentPortlet#515` — all ❌ on slf4j bridge rules

The common cause: those portlets are still on `spring.version=4.3.30.RELEASE`, which pre-dates `spring-jcl`. They genuinely need `jcl-over-slf4j` to route `commons-logging` calls into slf4j+logback, and `log4j-over-slf4j` to do the same for log4j calls. Banning the bridges outright broke migration for every Spring-4.x descendant.

Spring 5+ ships `spring-jcl` which obsoletes `jcl-over-slf4j`, so the ban was appropriate *once all descendants reached Spring 5+* — but we're not there yet.

## The fix

Remove the two ban lines. Re-add them in a future parent version once all descendants have moved to Spring 5+.

## Kept strict (security-driven, not lifted)

| Exclusion | Why |
|---|---|
| `commons-collections:commons-collections:[3.2.1,4.0]` | CVE-2015-6420 (RCE via deserialization) |
| `javax.servlet:servlet-api` | Bad transitive via portlet-mvc-util |
| `commons-logging:commons-logging` | Routed through slf4j |
| `org.apache.logging.log4j` | Project uses logback, not log4j-2 |
| `log4j` | log4j-1.x is EOL + vulnerable |

Also removed a stray duplicate `commons-collections` line that had crept in at some point.

## Release plan

Cut **uportal-portlet-parent:46** after this merges. Then the 10 open portlet-migration PRs get retargeted from `v45` → `v46` and should all go green.

## Test plan

- [x] `mvn help:effective-pom -N` — BUILD SUCCESSFUL
- [ ] After v46 release + retarget, all 10 portlet PRs' CI should pass

## Why not fix the portlets instead

Each portlet would need commons-logging + log4j bridges excluded from their transitive deps and direct declarations. That's 8 PRs of real modernization work that doesn't move the portlets closer to Spring 5+ — it just hides the fact that they're on Spring 4.x. Relaxing the parent ban is the lighter-touch change that correctly reflects the current state of the ecosystem.