### PR TITLE
chore: v47 dedup sweep — promote common deps/plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,16 +113,17 @@
     <additionalReleaseArguments />
 
     <maven.site.plugin.ver>3.12.0</maven.site.plugin.ver>
-    <maven.compiler.plugin.ver>3.11.0</maven.compiler.plugin.ver>
+    <maven.compiler.plugin.ver>3.13.0</maven.compiler.plugin.ver>
     <maven.jar.plugin.ver>3.3.0</maven.jar.plugin.ver>
     <maven.war.plugin.ver>3.4.0</maven.war.plugin.ver>
-    <maven.release.plugin.ver>3.0.1</maven.release.plugin.ver>
+    <maven.release.plugin.ver>3.1.1</maven.release.plugin.ver>
     <maven.scm.provider.gitexe.ver>2.0.1</maven.scm.provider.gitexe.ver>
     <!-- Version 4.2 identifies numerous license failures while 2.11 considers the license headers valid -->
     <license.maven.plugin.ver>2.11</license.maven.plugin.ver>
     <maven.jasig.legal.plugin.ver>1.0.2</maven.jasig.legal.plugin.ver>
     <notice.maven.plugin.ver>2.0.0</notice.maven.plugin.ver>
     <maven.enforcer.plugin.ver>3.4.1</maven.enforcer.plugin.ver>
+    <lesscss.maven.plugin.ver>1.7.0.1.1</lesscss.maven.plugin.ver>
 
     <!-- Reporting plug-ins.  See http://maven.apache.org/plugins/ with an R in the type column
     for report options and versions. -->
@@ -131,7 +132,7 @@
     <maven.project.info.reports.plugin.ver>3.4.5</maven.project.info.reports.plugin.ver>
     <maven.pmd.plugin.ver>3.21.0</maven.pmd.plugin.ver>
     <maven.changelog.plugin.ver>2.3</maven.changelog.plugin.ver>
-    <maven.javadoc.plugin.ver>3.6.0</maven.javadoc.plugin.ver>
+    <maven.javadoc.plugin.ver>3.11.2</maven.javadoc.plugin.ver>
     <cobertura.maven.plugin.ver>2.7</cobertura.maven.plugin.ver>
     <taglist.maven.plugin.ver>3.0.0</taglist.maven.plugin.ver>
     <findbugs.maven.plugin.ver>3.0.5</findbugs.maven.plugin.ver>
@@ -161,13 +162,19 @@
     <spring-data.version>2.7.18</spring-data.version>
     <portletmvc4spring.version>5.2.0</portletmvc4spring.version>
     <portlet-api.version>2.0</portlet-api.version>
-    <logback.version>1.3.5</logback.version>
-    <slf4j.version>2.0.6</slf4j.version>
-    <lombok.version>1.18.28</lombok.version>
+    <logback.version>1.3.12</logback.version>
+    <slf4j.version>2.0.17</slf4j.version>
+    <lombok.version>1.18.38</lombok.version>
     <servlet.version>3.1.0</servlet.version>
     <jstl.version>1.1.2</jstl.version>
+    <taglibs-standard.version>1.1.2</taglibs-standard.version>
     <junit.version>4.13.2</junit.version>
     <mockito.version>4.9.0</mockito.version>
+    <jackson.version>2.18.6</jackson.version>
+    <httpclient.version>4.5.14</httpclient.version>
+    <ehcache-core.version>2.6.11</ehcache-core.version>
+    <commons-lang.version>2.6</commons-lang.version>
+    <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
   </properties>
 
   <dependencyManagement>
@@ -326,11 +333,82 @@
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
       </dependency>
+      <!--
+        | slf4j bridges routing competing logging APIs to slf4j so the
+        | logback binding sees everything. Descendants on Spring 4.x need
+        | jcl-over-slf4j (Spring 5+ ships spring-jcl and obsoletes it).
+        | log4j-over-slf4j catches libraries that still call log4j 1.x APIs.
+      +-->
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>log4j-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jul-to-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${logback.version}</version>
         <scope>runtime</scope>
+      </dependency>
+
+      <!--
+        | Commonly-used libraries promoted in v47 after the v46 audit showed
+        | ≥5 portlets pinning identical versions. Descendants drop their own
+        | <version> and inherit here.
+      +-->
+      <dependency>
+        <groupId>commons-lang</groupId>
+        <artifactId>commons-lang</artifactId>
+        <version>${commons-lang.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>taglibs</groupId>
+        <artifactId>standard</artifactId>
+        <version>${taglibs-standard.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>${javax-annotation-api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${httpclient.version}</version>
+        <exclusions>
+          <!-- Every descendant excludes this already; fold it in here. -->
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>net.sf.ehcache</groupId>
+        <artifactId>ehcache-core</artifactId>
+        <version>${ehcache-core.version}</version>
+      </dependency>
+      <!--
+        | Jackson: import the BOM so all jackson-* artifacts stay version-aligned,
+        | and descendants can pull jackson-databind / jackson-annotations / etc.
+        | without redeclaring versions.
+      +-->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
     </dependencies>
@@ -582,6 +660,18 @@
               </goals>
             </execution>
           </executions>
+        </plugin>
+        <!--
+          | lesscss compiles LESS → CSS at build time. Used by several
+          | portlets with a Bootstrap/Fluid heritage (Calendar, Announcements,
+          | NewsReader, SimpleContent, Feedback). Descendants inherit the
+          | version; per-project <configuration> (input/output paths) still
+          | lives in each child POM.
+        +-->
+        <plugin>
+          <groupId>org.lesscss</groupId>
+          <artifactId>lesscss-maven-plugin</artifactId>
+          <version>${lesscss.maven.plugin.ver}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
## Summary

Audit across the 10 actively-maintained portlet repos showed a set of libraries pinned identically in ≥5 POMs. Promoting them here so each descendant can drop its own `<version>` and inherit.

## Changes

**`<dependencyManagement>` additions**

| artifact | version | # portlets | rationale |
|---|---|---|---|
| `commons-lang:commons-lang` | 2.6 | 8 | ubiquitous StringUtils etc. |
| `taglibs:standard` | 1.1.2 | 9 | JSTL 1.1 impl companion to `javax.servlet:jstl` |
| `javax.annotation:javax.annotation-api` | 1.3.2 | 5 | Java 11 bundled annotations |
| `org.apache.httpcomponents:httpclient` | 4.5.14 | 6 | + `commons-logging` exclusion folded in |
| `net.sf.ehcache:ehcache-core` | 2.6.11 | 5 | legacy ehcache 2.x for portlets still on Spring 4 |
| `com.fasterxml.jackson:jackson-bom` (import) | 2.18.6 | 7 | covers `jackson-core`, `jackson-databind`, `jackson-annotations` all version-aligned |
| `org.slf4j:jcl-over-slf4j` | ${slf4j.version} | 9 | bridge: commons-logging → slf4j |
| `org.slf4j:log4j-over-slf4j` | ${slf4j.version} | 9 | bridge: log4j 1.x → slf4j |
| `org.slf4j:jul-to-slf4j` | ${slf4j.version} | 10 | bridge: java.util.logging → slf4j |

**`<pluginManagement>` additions**

| plugin | version | # portlets |
|---|---|---|
| `org.lesscss:lesscss-maven-plugin` | 1.7.0.1.1 | 5 |

**Version bumps (parent was lagging descendants)**

- `slf4j` 2.0.6 → 2.0.17
- `logback-classic` 1.3.5 → 1.3.12
- `lombok` 1.18.28 → 1.18.38 (Java 17/21 readiness)
- `maven-compiler-plugin` 3.11.0 → 3.13.0
- `maven-release-plugin` 3.0.1 → 3.1.1
- `maven-javadoc-plugin` 3.6.0 → 3.11.2

**Explicitly NOT promoted** — heterogeneous across the portlet fleet and modernization-in-progress:

- Spring (4.3.30 vs 5.3.28 during the Spring 4→5 migration)
- Hibernate (3.2.7 → 5.6.15 spread)
- Mockito (3.12.4 → 5.23.0 spread)

## Test plan

- [x] `mvn validate` passes (enforcer: Java + BannedDependencies)
- [x] `mvn install -N` publishes to `~/.m2/repository/org/jasig/portlet/uportal-portlet-parent/47-SNAPSHOT/`
- [x] `mvn help:effective-pom -N` shows all new dM entries resolving to the intended versions
- [ ] Follow-up: one PR per portlet removing the now-redundant per-project version pins and verifying CI still passes (v46 → v47)

🤖 Generated with [Claude Code](https://claude.com/claude-code)