### PR TITLE
chore: bump logback.version 1.3.12 → 1.5.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
     <spring-data.version>2.7.18</spring-data.version>
     <portletmvc4spring.version>5.2.0</portletmvc4spring.version>
     <portlet-api.version>2.0</portlet-api.version>
-    <logback.version>1.3.12</logback.version>
+    <logback.version>1.5.32</logback.version>
     <slf4j.version>2.0.17</slf4j.version>
     <lombok.version>1.18.38</lombok.version>
     <servlet.version>3.1.0</servlet.version>


### PR DESCRIPTION
## Summary

Promotes the **logback 1.5.x** line to the whole portlet fleet for security fixes. Currently:

- Parent pins `logback.version=1.3.12`
- basiclti-portlet + BookmarksPortlet override locally to `1.5.16`
- The other 7 portlets inherit the parent's `1.3.12`

Bumping the parent brings the fleet into one current, maintained, security-patched line. basiclti and Bookmarks can drop their local overrides on their next parent bump.

## Compatibility

- **Java baseline**: logback 1.5.x requires Java 11+ — matches the fleet (all 9 portlets deploy on Java 11).
- **SLF4J**: same 2.x binding contract as 1.3.x — no API break for `org.slf4j.Logger` usage.
- **`javax.servlet` → `jakarta.servlet`**: this was the big compat change in 1.4+, but it only affects `logback-access`. Verified via `grep -r logback-access` across all 9 portlets — no portlet depends on `logback-access`. The `logback-classic` module used everywhere is unaffected.

## Test plan

- [x] `mvn validate` passes locally
- [ ] CI validates on merge + new parent release (v48)

🤖 Generated with [Claude Code](https://claude.com/claude-code)