### PR TITLE
chore: promote common license-plugin excludes for v49

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -553,6 +553,22 @@
               <exclude>src/main/webapp/js/**</exclude> -->
               <!-- Generated from commands such as `mvn site` -->
               <exclude>catalina.base_IS_UNDEFINED/**</exclude>
+              <!--
+                | Promoted from per-portlet license-plugin configs (v48 audit
+                | found these in 4-11 portlets each, none with conflicts):
+                |   target/**         build output (6 portlets)
+                |   release.properties maven-release-plugin checkpoint (4)
+                |   .gitignore        git config (6)
+                |   .idea/**          IntelliJ workspace (10/11)
+                |   overlays/**       portlet WAR overlay scratch (10/11)
+                |   **/src/main/webapp/rs/** resource-server-aggregated assets (5)
+              +-->
+              <exclude>target/**</exclude>
+              <exclude>release.properties</exclude>
+              <exclude>.gitignore</exclude>
+              <exclude>.idea/**</exclude>
+              <exclude>overlays/**</exclude>
+              <exclude>**/src/main/webapp/rs/**</exclude>
             </excludes>
             <mapping>
               <channel>XML_STYLE</channel>


### PR DESCRIPTION
## Summary

Folds 6 boilerplate `<exclude>` patterns into the parent's `license-maven-plugin` configuration so descendant portlets can drop their local copies. Net effect: less boilerplate per portlet, fewer drift opportunities, and v49 ships a saner license check out of the box.

## Audit data behind the change

Surveyed `license-maven-plugin` configs across all 11 Maven-based portlet repos on parent v48. Six exclude patterns appear in 4-11 repos each, with no conflicts:

| Exclude | Repo count (of 11) | What it excludes |
|---|---|---|
| `target/**` | 6 | Maven build output |
| `release.properties` | 4 | `maven-release-plugin` checkpoint |
| `.gitignore` | 6 | Git config |
| `.idea/**` | 10 | IntelliJ workspace |
| `overlays/**` | 10 | Portlet WAR overlay scratch dir |
| `**/src/main/webapp/rs/**` | 5 | resource-server-aggregated frontend assets |

None of these paths legitimately need an Apereo license header — they're build output, IDE state, vendored/aggregated assets, or release tooling artifacts.

## Changes

`pom.xml` — add 6 `<exclude>` entries inside `pluginManagement` → `license-maven-plugin` → `<configuration>` → `<excludes>`. A comment block above the additions captures the audit context.

Net diff: 16 lines added, 0 removed, 1 file.

## Out of scope (intentional)

- **`<less>` mapping**: parent stays on `SLASHSTAR_STYLE`. Two portlets drift (AnnouncementsPortlet uses `DOUBLESLASH_STYLE`, CoursesPortlet uses `JAVADOC_STYLE`) — those will be fixed in follow-up portlet PRs that run `mvn license:format` on ~7 `.less` files total.
- **basiclti-portlet**: keeps its own `<plugin>` block (uses the legacy `com.mycila.maven-license-plugin:maven-license-plugin:1.9.0` coordinate, predates the artifact rename to `com.mycila:license-maven-plugin`). A separate PR will migrate it to inherit parent.
- **Outlier excludes** (1-2 repos each — `docs/**`, `**/*.json`, `src/main/webapp/css/**`, `**/node_modules/**`, MS Exchange WSDL, etc.): kept local since they're genuinely portlet-specific.

## Test plan

- [x] `mvn clean install -DskipTests=true -Dgpg.skip=true` against the parent — green
- [ ] CI on the parent repo (whatever workflows are wired up)
- [ ] Smoke-test in a follow-up portlet PR (CoursesPortlet plugin sweep) — install parent locally with `-SNAPSHOT` and verify `mvn license:check` still passes after dropping the portlet's local `<excludes>`
- [ ] Once cut as v49, sweep PRs across the fleet to bump parent and shrink each portlet's local `license-maven-plugin` config

## Follow-ups (not in this PR)

1. Cut the v49 release once this lands.
2. CoursesPortlet plugin sweep (closes Renovate #94 and #97): drop redundant plugin pins; drop the stale `<header>https://source.jasig.org/...` URL; run `license:format` to fix 19 leftover "Licensed to Jasig" stragglers.
3. AnnouncementsPortlet: drop local `<less>DOUBLESLASH_STYLE</less>` mapping; `license:format` rewrites 4 `.less` files.
4. basiclti-portlet: drop the legacy `com.mycila.maven-license-plugin:1.9.0` block; inherit parent. Source files already use the Apereo header so no source rewrite needed.
5. Per-portlet sweeps to delete the now-redundant local `<excludes>` blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)