### PR TITLE
chore: bump maven-war-plugin 3.4.0 → 3.5.1 for plexus-archiver CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,15 @@
     <maven.site.plugin.ver>3.12.0</maven.site.plugin.ver>
     <maven.compiler.plugin.ver>3.13.0</maven.compiler.plugin.ver>
     <maven.jar.plugin.ver>3.3.0</maven.jar.plugin.ver>
-    <maven.war.plugin.ver>3.4.0</maven.war.plugin.ver>
+    <!--
+      | 3.5.1 bundles plexus-archiver 4.10.4, which patches
+      | CVE-2023-37460 (Arbitrary File Creation in AbstractUnArchiver,
+      | CVSS 8.1, fixed in plexus-archiver 4.8.0). 3.4.0 bundled
+      | plexus-archiver 4.7.1 (vulnerable). Real-world risk for portlet
+      | builds is low (we create WARs, the CVE is in the unarchive path)
+      | but the parent should not ship a vulnerable transitive by default.
+    +-->
+    <maven.war.plugin.ver>3.5.1</maven.war.plugin.ver>
     <maven.release.plugin.ver>3.1.1</maven.release.plugin.ver>
     <maven.scm.provider.gitexe.ver>2.0.1</maven.scm.provider.gitexe.ver>
     <!-- Version 4.2 identifies numerous license failures while 2.11 considers the license headers valid -->


### PR DESCRIPTION
## Summary

Bumps `<maven.war.plugin.ver>` from `3.4.0` to `3.5.1` so descendant Maven portlets pick up plexus-archiver **4.10.4** (which patches CVE-2023-37460) automatically via inheritance.

## CVE detail

**[GHSA-wh3p-fphp-9h2m](https://github.com/advisories/GHSA-wh3p-fphp-9h2m) / CVE-2023-37460** — *Arbitrary File Creation in AbstractUnArchiver*, CVSS 8.1 HIGH.

> When extracting an archive with an entry whose name resolves through an existing symlink to outside the destination directory, `resolveFile()` returns the symlink source. Possible RCE.

Vulnerable: `plexus-archiver < 4.8.0`. Fixed in `4.8.0+`.

| Component | plexus-archiver | CVE status |
|---|---|---|
| `maven-war-plugin:3.4.0` (current parent default) | bundles `4.7.1` | **Vulnerable** |
| `maven-war-plugin:3.5.1` (this PR) | bundles `4.10.4` | **Patched** |

## Real-world risk for our builds: low

The vulnerability is in the **un**archiver code path (`AbstractUnArchiver.resolveFile()`). Our portlets use plexus-archiver to *create* WARs at build time, not to extract untrusted archives. Even our `<overlays>` come from trusted Maven artifacts (`resource-server-content` etc.), not user input. But the parent shouldn't ship a known-vulnerable transitive by default, and there's no reason for descendants to pin `maven-war-plugin` locally to work around it.

## Changes

`pom.xml`:
- `<maven.war.plugin.ver>3.4.0</>` → `<maven.war.plugin.ver>3.5.1</>`.
- Comment block above the property records the CVE context.


## Companion PR

[SimpleContentPortlet#544](https://github.com/uPortal-Project/SimpleContentPortlet/pull/544) drops a plugin-level `plexus-archiver:4.11.0` override that has been pinned on `maven-war-plugin` since May 2025. That pin had no real CVE context (4.4.0 → 4.7.1 → 4.11.0 are all newer than the bundled version, and Renovate's escalation eventually broke the classpath against `commons-io 2.13.0`). After v50 ships, the SimpleContent fix means it gets the patched plexus-archiver 4.10.4 cleanly via the parent.

## Test plan

- [x] `mvn clean install -Dgpg.skip=true` against the parent — green
- [ ] CI on the parent
- [ ] Smoke-test against a descendant portlet by bumping `<parent>` to `50-SNAPSHOT` locally and running `mvn install` (skipped here; parent is pom-only and the property change is a one-line bump)
- [ ] Once cut as v50, sweep PRs across the fleet to bump parent (Renovate will start opening these the same day v50 publishes)

## What's NOT in this PR (intentional)

- The per-portlet `<excludes combine.children="append">` guidance from the v49 sweep findings — that's a doc/comment improvement, not a code change, and can land in a future cycle when there's other reason to cut a release.
- A `renovate.json` `packageRules` group bundling `plexus-archiver` with `commons-io` — only relevant if a descendant ever needs to override `plexus-archiver` again. Not needed for the default case.
