### PR TITLE
chore: replace commons-lang 2.6 with commons-lang3 3.20.0 + commons-text 1.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,14 @@
     <jackson.version>2.18.6</jackson.version>
     <httpclient.version>4.5.14</httpclient.version>
     <ehcache-core.version>2.6.11</ehcache-core.version>
-    <commons-lang.version>2.6</commons-lang.version>
+    <!--
+      | commons-lang 2.x is end-of-life and carries CVE-2025-48924 with no
+      | upstream fix. The fleet migrates to commons-lang3 (package rename:
+      | org.apache.commons.lang -> org.apache.commons.lang3) and to
+      | commons-text for the StringEscapeUtils class that lang3 spun off.
+    +-->
+    <commons-lang3.version>3.20.0</commons-lang3.version>
+    <commons-text.version>1.15.0</commons-text.version>
     <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
   </properties>
 
@@ -373,11 +380,22 @@
         | Commonly-used libraries promoted in v47 after the v46 audit showed
         | ≥5 portlets pinning identical versions. Descendants drop their own
         | <version> and inherit here.
+        |
+        | v51: commons-lang 2.x dropped (CVE-2025-48924, no upstream fix);
+        | replaced with commons-lang3 + commons-text. Descendant portlets
+        | must rename source imports org.apache.commons.lang.*
+        | -> org.apache.commons.lang3.* in the same v51 bump, and switch
+        | StringEscapeUtils imports to org.apache.commons.text.*.
       +-->
       <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>${commons-lang.version}</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons-lang3.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>${commons-text.version}</version>
       </dependency>
       <dependency>
         <groupId>taglibs</groupId>


### PR DESCRIPTION
## Summary

Drops the end-of-life `commons-lang:commons-lang:2.6` from the parent dM and provides modern `commons-lang3:3.20.0` + `commons-text:1.15.0` instead. Closes the security gap from CVE-2025-48924 (GHSA-jcpc-3jpw-vfhw, no upstream fix in the 2.x line) and gives descendant portlets the path to migrate.

## Why

`commons-lang` 2.x has been EOL since 2011 (the Apache project superseded it with `commons-lang3`). The `StringEscapeUtils` class was further spun off into `commons-text` in 2017. CVE-2025-48924 sits unfixed in the 2.x line and has no plan to be patched — the only safe path is the package rename to lang3.

The fleet survey found 9 descendant portlets importing `org.apache.commons.lang.*` in source. Migrating each is a mostly-mechanical package rename (`lang` → `lang3`) with one exception: `StringEscapeUtils` callers (basiclti only) need their import switched to `org.apache.commons.text.StringEscapeUtils` and a new `commons-text` dependency.

## Changes

`pom.xml`:
- Replace `<commons-lang.version>2.6</>` property with `<commons-lang3.version>3.20.0</>` and `<commons-text.version>1.15.0</>`.
- Replace the `commons-lang:commons-lang` dM entry with `org.apache.commons:commons-lang3` and `org.apache.commons:commons-text` dM entries.
- Comment above the dM entries documents the source-rename descendants must do.

## Coordinated descendant rollout (will follow this PR)

After v51 ships, each affected portlet gets a single PR that:

1. Bumps `<parent>` v50 → v51.
2. Updates `pom.xml` dependency declarations: `commons-lang:commons-lang` → `org.apache.commons:commons-lang3`. (basiclti also adds `commons-text`.)
3. Sed source imports: `org.apache.commons.lang.*` → `org.apache.commons.lang3.*`. (basiclti's `StringEscapeUtils` import → `org.apache.commons.text.StringEscapeUtils`.)
4. Verifies `mvn clean install` builds green.

| Portlet | Source import count | Pom action | Notes |
|---|---|---|---|
| AnnouncementsPortlet | 5 | declare lang3 (was transitive) | |
| basiclti-portlet | 5 | swap to lang3 + add commons-text | uses `StringEscapeUtils` |
| BookmarksPortlet | 8 | swap to lang3 | |
| CalendarPortlet | 12 | swap to lang3 | also `time.FastDateFormat` (lang3 still has it) |
| FeedbackPortlet | 0 | drop the unused dep entirely | declared but never imported |
| JasigWidgetPortlets | 7 | swap to lang3 | |
| NewsReaderPortlet | 8 | swap to lang3 | |
| SimpleContentPortlet | 6 | declare lang3 (was transitive) | |
| WebproxyPortlet | 8 | declare lang3 (was transitive) | |

CoursesPortlet and resource-server have zero `commons-lang` imports — they need only the routine v51 parent bump.

## Test plan

- [x] `mvn clean install -Dgpg.skip=true` against the parent — green
- [ ] CI on the parent
- [ ] Per-portlet migration PRs verify their own builds against `parent:51`

## Out of scope

- **commons-httpclient 3.x → httpclient 4.x migration** (the next CVE batch on the fleet) — separate effort, separate parent bump if any.
- **Lombok adoption** to replace `EqualsBuilder`/`HashCodeBuilder`/`ToStringBuilder` patterns. lang3 still provides these and Lombok is already in parent v50 dM if a portlet wants to opt in independently.